### PR TITLE
Added some tests for ChicagoObjectDecoder

### DIFF
--- a/src/main/java/com/xjeffrose/chicago/ChicagoObjectDecoder.java
+++ b/src/main/java/com/xjeffrose/chicago/ChicagoObjectDecoder.java
@@ -43,19 +43,19 @@ public class ChicagoObjectDecoder extends ByteToMessageDecoder {
         UUID id = chiMsg.getId();
         Op op = chiMsg.getOp();
         byte[] colFam = chiMsg.getColFam();
-        byte[] key = chiMsg.getKey();
         ByteBuf bb = Unpooled.buffer();
 
         for (Object cm : out) {
           lastOffset = ((ChicagoMessage)cm).getKey();
           bb.writeBytes(((ChicagoMessage)cm).getVal());
+          // TODO: It would be more efficient to use `writeByte(0)`
           bb.writeBytes(new byte[]{'\0'});
         }
 
+        // TODO: This feels dangerous to me, we should be specifying the charset not using system default
         bb.writeBytes(ChiUtil.delimiter.getBytes());
         bb.writeBytes(lastOffset);
         out.clear();
-        byte[] val = bb.array();
         ChicagoMessage cm = new DefaultChicagoMessage(id,op,colFam,Boolean.toString(true).getBytes(),bb.array());
         cm.setDecoderResult(DecoderResult.SUCCESS);
         out.add(cm);

--- a/src/main/java/com/xjeffrose/chicago/DefaultChicagoMessage.java
+++ b/src/main/java/com/xjeffrose/chicago/DefaultChicagoMessage.java
@@ -9,7 +9,7 @@ import lombok.ToString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@EqualsAndHashCode(exclude={})
+@EqualsAndHashCode(exclude={"decoderResult"})
 @ToString(exclude={})
 public class DefaultChicagoMessage implements ChicagoMessage {
   private static final Logger log = LoggerFactory.getLogger(DefaultChicagoMessage.class.getName());


### PR DESCRIPTION
Not all of these tests pass.  The tests show my understanding of how
the decoder should be working, but my understanding might be off.

This is meant to start a conversation on what I'm not understanding
or how the code can be improved.

My thoughts are that the encoder and decoder should be mirrors
of each other.  Aggregating a STREAM_RESPONSE probably shouldn't
be in the decoder, that belongs in an Aggregator (Message->Message)

To handle the case where a STREAM_RESPONSE is spread over multiple
netty ByteBuf's there needs to be a token message sent to mark the
end of a stream.  I see the decoder trying to add such a marking
in the aggregated ChicagoMessage, but I don't see the encoder doing
anything like that, which makes proper decoding difficult.
